### PR TITLE
Expression Typechecking

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@
 //! The main crate for the compiler of the Skopje programming language.
 mod parser;
 mod transpiler;
+mod semantics;
 
 use transpiler::transpile_c::Transpiler;
 

--- a/src/parser/lexing.rs
+++ b/src/parser/lexing.rs
@@ -360,6 +360,8 @@ impl Scanner {
                             "while" => return Ok(TokenType::WhileKeyword),
                             "let" => return Ok(TokenType::LetKeyword),
                             "do" => return Ok(TokenType::DoKeyword),
+                            "true" => return Ok(TokenType::BoolLiteral(true)),
+                            "false" => return Ok(TokenType::BoolLiteral(false)),
                             // is not a keyword, and therefore is an identifier
                             _ => return Ok(TokenType::Identifier(token_text.to_owned()))
                         }

--- a/src/parser/lexing.rs
+++ b/src/parser/lexing.rs
@@ -326,7 +326,7 @@ impl Scanner {
             }
 
             "|" => {
-                if let Some('=') = self.peek(line, 0) {
+                if let Some('|') = self.peek(line, 0) {
                     self.advance();
                     return Ok(TokenType::DoublePipe);
                 } else {

--- a/src/parser/parsing.rs
+++ b/src/parser/parsing.rs
@@ -449,6 +449,9 @@ impl Parser {
         assert!(matches!(next_token.token_type, TokenType::OpenParen));
 
         let expr = self.parse_expression()?;
+        if !get_expr_type(&expr, &self.context).unwrap().contains(&Type::new(SimpleType::Bool, false, vec![]).unwrap()) {
+            panic!("If statement's condition must be of type bool!");
+        }
 
         let next_token = self.tokens.pop_front().unwrap();
         assert!(matches!(next_token.token_type, TokenType::CloseParen));

--- a/src/parser/parsing.rs
+++ b/src/parser/parsing.rs
@@ -333,6 +333,10 @@ impl Parser {
         assert!(matches!(next_token.token_type, TokenType::Equal));
 
         let expr = self.parse_expression()?;
+        let expr_type: TypeField = get_expr_type(&expr).unwrap();
+        if !expr_type.contains(&self.context.valid_identifiers.get(&id).unwrap().0) {
+            panic!("Mismatch between variable and expression types!");
+        }
 
         let next_token = self.tokens.pop_front().unwrap();
         assert!(matches!(next_token.token_type, TokenType::Semicolon));

--- a/src/parser/parsing.rs
+++ b/src/parser/parsing.rs
@@ -65,6 +65,7 @@ pub enum SyntaxNode {
     FunctionCallStmt(String, Vec<SyntaxTree>),
     StringLiteral(String),
     IntLiteral(u64),
+    BoolLiteral(bool),
     Identifier(String)
 }
 
@@ -623,6 +624,7 @@ impl Parser {
         match next_token.token_type {
             TokenType::StrLiteral(s) => Ok(SyntaxTree::new(SyntaxNode::StringLiteral(s))),
             TokenType::IntLiteral(n) => Ok(SyntaxTree::new(SyntaxNode::IntLiteral(n))),
+            TokenType::BoolLiteral(b) => Ok(SyntaxTree::new(SyntaxNode::BoolLiteral(b))),
             TokenType::DoKeyword => self.parse_do_block(),
 
             TokenType::Identifier(id) => {

--- a/src/parser/parsing.rs
+++ b/src/parser/parsing.rs
@@ -715,13 +715,22 @@ impl Parser {
         assert!(matches!(next_token.token_type, TokenType::OpenParen));
 
         let cond = self.parse_expression()?;
+        if !get_expr_type(&cond).unwrap().contains(&Type::new("bool".to_owned(), false, vec![]).unwrap()) {
+            panic!("If statement's condition must be of type bool!");
+        }
 
         let next_token = self.tokens.pop_front().unwrap();
         assert!(matches!(next_token.token_type, TokenType::CloseParen));
 
         let next_token = self.tokens.pop_front().unwrap();
         let if_body = match next_token.token_type {
-            TokenType::OpenCurly => self.parse_stmt_block()?,
+            TokenType::OpenCurly => {
+                let result = self.parse_stmt_block()?;
+                let next_token = self.tokens.pop_front().unwrap();
+                assert!(matches!(next_token.token_type, TokenType::CloseCurly));
+                result
+            },
+
             _ => {
                 self.tokens.push_front(next_token);
                 vec![self.parse_statement()?]
@@ -733,7 +742,13 @@ impl Parser {
             TokenType::ElseKeyword => {
                 let next_token = self.tokens.pop_front().unwrap();
                 Some(match next_token.token_type {
-                    TokenType::OpenCurly => self.parse_stmt_block()?,
+                    TokenType::OpenCurly => {
+                        let result = self.parse_stmt_block()?;
+                        let next_token = self.tokens.pop_front().unwrap();
+                        assert!(matches!(next_token.token_type, TokenType::CloseCurly));
+                        result
+                    },
+
                     _ => {
                         self.tokens.push_front(next_token);
                         vec![self.parse_statement()?]

--- a/src/parser/parsing.rs
+++ b/src/parser/parsing.rs
@@ -3,6 +3,7 @@ use std::error::Error;
 
 use crate::semantics::typechecking::{TypeField, get_expr_type};
 
+use super::types::SimpleType;
 use super::{errors::ParsingError, token::*, types::Type};
 
 
@@ -104,8 +105,8 @@ pub struct Context {
 impl Context {
     pub fn new() -> Self {
         let mut valid_identifiers: HashMap<String, (Type, usize)> = HashMap::new();
-        valid_identifiers.insert("print".to_owned(), (Type::new("void".to_owned(), false, vec![]).unwrap(), 0));
-        valid_identifiers.insert("readln".to_owned(), (Type::new("void".to_owned(), false, vec![]).unwrap(), 0));
+        valid_identifiers.insert("print".to_owned(), (Type::new(SimpleType::Void, false, vec![]).unwrap(), 0));
+        valid_identifiers.insert("readln".to_owned(), (Type::new(SimpleType::Void, false, vec![]).unwrap(), 0));
 
         Context {
             valid_identifiers,
@@ -131,6 +132,22 @@ impl Context {
                                      .filter(|(_, (_, window_id))| window_id != context_window)
                                      .map(|(k, (t, w))| (k.clone(), (t.clone(), *w)))
                                      .collect();
+    }
+
+
+    /// Checks if the passed identifier is a valid function in the given context and returns the
+    /// type of the function if it is, and `None` if it isn't.
+    pub fn verify_function(&self, func_name: &String) -> Option<Type> {
+        match self.valid_identifiers.get(func_name) {
+            Some((func_type, _)) => {
+                match func_type.basic_type {
+                    SimpleType::Function(_, _) => Some(func_type.clone()),
+                    _ => None
+                }
+            }
+
+            None => None
+        }
     }
 }
 
@@ -203,7 +220,6 @@ impl Parser {
             let arrow = self.tokens.pop_front().unwrap();
             assert!(matches!(arrow.token_type, TokenType::Arrow));
 
-            // TODO: make this work will all function types
             let return_type = self.parse_type().unwrap();
 
             let open_body = self.tokens.pop_front().unwrap();
@@ -214,6 +230,12 @@ impl Parser {
             let close_body = self.tokens.pop_front().unwrap();
             assert!(matches!(close_body.token_type, TokenType::CloseCurly));
             
+            // add this function to the valid functions available in this context
+            let func_type = Type::new(SimpleType::Function(
+                Box::new(return_type.clone()), params.iter().map(|(_, t)| t).cloned().collect::<Vec<Type>>()
+            ), false, vec![])?;
+            self.context.add_var(id.clone(), func_type);
+
             return Ok(SyntaxTree::new(
                 SyntaxNode::Function(id, params, return_type, body)
             ));
@@ -256,7 +278,7 @@ impl Parser {
             // TODO: make this work with all param types
             let next_token = self.tokens.pop_front().unwrap();
             if let TokenType::Identifier(t) = next_token.token_type {
-                p_type = Type::new(t, false, vec![]).unwrap();
+                p_type = Type::new_str(t, false, vec![]).unwrap();
             } else {
                 return Err(ParsingError::UnexpectedToken(next_token));
             }
@@ -418,7 +440,7 @@ impl Parser {
             _ => vec![] // no generic
         };
 
-        Ok(Type::new(basic_type, false, generics)?)
+        Ok(Type::new_str(basic_type, false, generics)?)
     }
 
 
@@ -443,11 +465,19 @@ impl Parser {
 
 
     fn parse_func_call_stmt(&mut self, id: String) -> Result<SyntaxTree, ParsingError> {
+        // check that the function exists in this context
+        match self.context.verify_function(&id) {
+            Some(_) => (),
+            None => panic!("Identifier {} is not valid in this context", id)
+        }
+
         let next_token = self.tokens.pop_front().unwrap();
         if let TokenType::OpenParen = next_token.token_type {
             let arguments: Vec<SyntaxTree> = self.parse_func_args()?;
             if let TokenType::Semicolon = self.tokens.pop_front().unwrap().token_type {
-                return Ok(SyntaxTree::new(SyntaxNode::FunctionCallStmt(id, arguments)));
+                let expr = SyntaxTree::new(SyntaxNode::FunctionCallStmt(id, arguments));
+                get_expr_type(&expr, &self.context).unwrap();
+                return Ok(expr);
             }
         }
         
@@ -715,7 +745,7 @@ impl Parser {
         assert!(matches!(next_token.token_type, TokenType::OpenParen));
 
         let cond = self.parse_expression()?;
-        if !get_expr_type(&cond, &self.context).unwrap().contains(&Type::new("bool".to_owned(), false, vec![]).unwrap()) {
+        if !get_expr_type(&cond, &self.context).unwrap().contains(&Type::new(SimpleType::Bool, false, vec![]).unwrap()) {
             panic!("If statement's condition must be of type bool!");
         }
 

--- a/src/parser/parsing.rs
+++ b/src/parser/parsing.rs
@@ -1,6 +1,8 @@
 use std::collections::{HashMap, VecDeque};
 use std::error::Error;
 
+use crate::semantics::typechecking::{TypeField, get_expr_type};
+
 use super::{errors::ParsingError, token::*, types::Type};
 
 
@@ -358,6 +360,10 @@ impl Parser {
         assert!(matches!(next_token.token_type, TokenType::Equal));
 
         let expression: SyntaxTree = self.parse_expression()?;
+        let expr_type: TypeField = get_expr_type(&expression).unwrap();
+        if !expr_type.contains(&var_type) {
+            panic!("Mismatch between variable and expression types!");
+        }
 
         let next_token = self.tokens.pop_front().unwrap();
         assert!(matches!(next_token.token_type, TokenType::Semicolon));

--- a/src/parser/parsing.rs
+++ b/src/parser/parsing.rs
@@ -334,7 +334,7 @@ impl Parser {
         assert!(matches!(next_token.token_type, TokenType::Equal));
 
         let expr = self.parse_expression()?;
-        let expr_type: TypeField = get_expr_type(&expr).unwrap();
+        let expr_type: TypeField = get_expr_type(&expr, &self.context).unwrap();
         if !expr_type.contains(&self.context.valid_identifiers.get(&id).unwrap().0) {
             panic!("Mismatch between variable and expression types!");
         }
@@ -365,7 +365,7 @@ impl Parser {
         assert!(matches!(next_token.token_type, TokenType::Equal));
 
         let expression: SyntaxTree = self.parse_expression()?;
-        let expr_type: TypeField = get_expr_type(&expression).unwrap();
+        let expr_type: TypeField = get_expr_type(&expression, &self.context).unwrap();
         if !expr_type.contains(&var_type) {
             panic!("Mismatch between variable and expression types!");
         }
@@ -715,7 +715,7 @@ impl Parser {
         assert!(matches!(next_token.token_type, TokenType::OpenParen));
 
         let cond = self.parse_expression()?;
-        if !get_expr_type(&cond).unwrap().contains(&Type::new("bool".to_owned(), false, vec![]).unwrap()) {
+        if !get_expr_type(&cond, &self.context).unwrap().contains(&Type::new("bool".to_owned(), false, vec![]).unwrap()) {
             panic!("If statement's condition must be of type bool!");
         }
 

--- a/src/parser/token.rs
+++ b/src/parser/token.rs
@@ -53,6 +53,7 @@ pub enum TokenType {
     WhileKeyword,
     StrLiteral(String),
     IntLiteral(u64),
+    BoolLiteral(bool),
     Identifier(String)
 }
 

--- a/src/parser/types.rs
+++ b/src/parser/types.rs
@@ -39,7 +39,7 @@ impl SimpleType {
 
 
 /// Encodes a type, including the dependencies and linearity, of a value in Skopje. 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Type {
     pub basic_type: SimpleType,
     pub monadic: bool,

--- a/src/parser/types.rs
+++ b/src/parser/types.rs
@@ -8,6 +8,7 @@ pub enum SimpleType {
     U32,
     Str,
     Void,
+    Bool,
     IOMonad
 }
 
@@ -19,6 +20,7 @@ impl SimpleType {
             "u32" => Self::U32,
             "str" => Self::Str,
             "void" => Self::Void,
+            "bool" => Self::Bool,
             "IO" => Self::IOMonad,
             name => return Err(Box::new(ParsingError::InvalidTypeName(name.to_owned())))
         })
@@ -32,6 +34,7 @@ impl SimpleType {
             Self::I32 => "int32_t",
             Self::U32 => "uint32_t",
             Self::Str => "std::string",
+            Self::Bool => "bool",
             Self::IOMonad => "IOMonad"
         }
     }

--- a/src/parser/types.rs
+++ b/src/parser/types.rs
@@ -9,6 +9,7 @@ pub enum SimpleType {
     Str,
     Void,
     Bool,
+    Function(Box<Type>, Vec<Type>), // return type, vec of params
     IOMonad
 }
 
@@ -28,14 +29,19 @@ impl SimpleType {
 
 
     /// Converts Skopje types to their closest equivalents in C using the stdint.h library.
-    pub fn as_ctype_str(&self) -> &str {
+    pub fn as_ctype_str(&self) -> String {
         match self {
-            Self::Void => "void",
-            Self::I32 => "int32_t",
-            Self::U32 => "uint32_t",
-            Self::Str => "std::string",
-            Self::Bool => "bool",
-            Self::IOMonad => "IOMonad"
+            Self::Void => String::from("void"),
+            Self::I32 => String::from("int32_t"),
+            Self::U32 => String::from("uint32_t"),
+            Self::Str => String::from("std::string"),
+            Self::Bool => String::from("bool"),
+            Self::IOMonad => String::from("IOMonad"),
+            Self::Function(return_type, params) => format!(
+                "std::function<{}({})>",
+                return_type.as_ctype_str(),
+                params.iter().map(|p| p.as_ctype_str()).collect::<Vec<String>>().join(", ")
+            )
         }
     }
 }
@@ -53,7 +59,7 @@ pub struct Type {
 
 
 impl Type {
-    pub fn new(basic_type: String, linear: bool, generics: Vec<Type>) -> Result<Self, Box<dyn Error>> {
+    pub fn new_str(basic_type: String, linear: bool, generics: Vec<Type>) -> Result<Self, Box<dyn Error>> {
         let basic_type = SimpleType::from_string(&basic_type)?;
         let monadic: bool = match basic_type {
             SimpleType::IOMonad => true,
@@ -65,6 +71,22 @@ impl Type {
             basic_type,
             monadic,
             linear,
+            generics
+        })
+    }
+
+
+    pub fn new(basic_type: SimpleType, linear: bool, generics: Vec<Type>) -> Result<Self, Box<dyn Error>> {
+        let monadic: bool = match basic_type {
+            SimpleType::IOMonad => true,
+            _ => false
+        };
+
+        Ok(Type {
+            dependencies: vec![], 
+            basic_type, 
+            monadic, 
+            linear, 
             generics
         })
     }

--- a/src/semantics/errors.rs
+++ b/src/semantics/errors.rs
@@ -1,0 +1,27 @@
+use std::{fmt, error};
+
+use super::typechecking::TypeField;
+
+
+#[derive(Debug)]
+pub struct TypeError {
+    expected: TypeField,
+    got: TypeField
+}
+
+
+impl TypeError {
+    pub fn new(expected: TypeField, got: TypeField) -> Self {
+         Self { expected, got }
+    }
+}
+
+
+impl fmt::Display for TypeError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Expected expression of type {:?}, got {:?}", self.expected, self.got)
+    }
+}
+
+
+impl error::Error for TypeError {}

--- a/src/semantics/mod.rs
+++ b/src/semantics/mod.rs
@@ -1,0 +1,2 @@
+pub mod typechecking;
+pub mod errors;

--- a/src/semantics/typechecking.rs
+++ b/src/semantics/typechecking.rs
@@ -37,6 +37,7 @@ impl TypeField {
                 Type::new("i32".to_owned(), false, vec![]).unwrap(),
                 Type::new("u32".to_owned(), false, vec![]).unwrap(),
                 Type::new("str".to_owned(), false, vec![]).unwrap(),
+                Type::new("bool".to_owned(), false, vec![]).unwrap(),
             ]
         }
     }
@@ -138,6 +139,14 @@ pub fn get_expr_type(expr: &SyntaxTree) -> Result<TypeField, Box<dyn Error>> {
             type_field.add(Type::new(String::from("str"), false, vec![])?);
             Ok(type_field)
         },
+
+        SyntaxNode::BoolLiteral(_) => {
+            let mut type_field = TypeField::new();
+            type_field.clear();
+            type_field.add(Type::new(String::from("bool"), false, vec![])?);
+            Ok(type_field)
+        }
+
         _ => todo!()
     }
 }

--- a/src/semantics/typechecking.rs
+++ b/src/semantics/typechecking.rs
@@ -163,9 +163,30 @@ fn get_binary_operation_type(op: String, l_type: TypeField, r_type: TypeField) -
             }
         }
 
-        "&&" | "||" => unimplemented!("Have not yet implemented booleans!"),
-        ">" | "<" | ">=" | "<=" => unimplemented!("Have not yet implemented booleans!"),
-        "==" | "!=" => unimplemented!("Have not yet implemented booleans!"),
+        // two boolean arguments and a boolean output
+        "&&" | "||" => {
+            let mut valid_field = TypeField::new();
+            valid_field.clear();
+            valid_field.add(Type::new("bool".to_owned(), false, vec![]).unwrap());
+
+            match intersection.contains(&Type::new("bool".to_owned(), false, vec![]).unwrap()) {
+                true => Ok(intersection),
+                false => Err(Box::new(TypeError::new(valid_field, intersection)))
+            }
+        },
+
+        ">" | "<" | ">=" | "<=" => {
+            let mut valid_field = TypeField::new();
+            valid_field.clear();
+            valid_field.add(Type::new("bool".to_owned(), false, vec![]).unwrap());
+
+            match intersection.contains_numeric() {
+                true => Ok(valid_field),
+                false => Err(Box::new(TypeError::new(TypeField::new_numeric(), intersection)))
+            }
+        },
+
+        "==" | "!=" => unimplemented!("Have not yet implemented equality!"),
         _ => panic!("Did not recognise operator {}", op)
     }
 }

--- a/src/semantics/typechecking.rs
+++ b/src/semantics/typechecking.rs
@@ -1,0 +1,171 @@
+//! This library is for typechecking expressions and function bodies according to Skopje's typing
+//! system - it does not concern itself with computational types.
+//! 
+//! Uses [`TypeField`] to steadily narrow down the possible types and expression may have and then,
+//! at the end, will pick the best if it is not clear. If at any point the type field for an
+//! expression is empty, then no progress can be made and the expression has a type error (which is
+//! implemented as [`TypeError`]).
+use std::error::Error;
+
+use crate::parser::parsing::{SyntaxNode, SyntaxTree};
+use crate::parser::types::{Type, SimpleType};
+
+use super::errors::TypeError;
+
+
+/// Used to denote a set of possible types that something may have. For example, we may know that 
+/// an expression has a numeric type, but not precicely which numeric type.
+/// 
+/// # Example
+/// 
+/// ```
+/// let type_field: TypeField = TypeField::new();
+/// ```
+#[derive(Debug)]
+pub struct TypeField {
+    valid_types: Vec<Type>
+}
+
+
+#[allow(unused)]
+impl TypeField {
+    /// Creates a new [`TypeField`] instance where the valid types are all the possible types
+    /// available in the given context of the program. 
+    pub fn new() -> Self {
+        TypeField {
+            valid_types: vec![
+                Type::new("i32".to_owned(), false, vec![]).unwrap(),
+                Type::new("u32".to_owned(), false, vec![]).unwrap(),
+                Type::new("str".to_owned(), false, vec![]).unwrap(),
+            ]
+        }
+    }
+
+
+    /// Creates a new [`TypeField`] instance where the valid types are all the possible 
+    /// <b>numerical</b> types available in the given context of the program. 
+    pub fn new_numeric() -> Self {
+        let mut field = Self::new();
+        field.restrict_numeric();
+        field
+    }
+
+
+    /// Removes all non_numerical types from the valid types in this instance of [`TypeField`].
+    pub fn restrict_numeric(&mut self) {
+        self.valid_types = self.valid_types
+                               .iter()
+                               .filter(|t| type_is_numeric(t))
+                               .cloned()
+                               .collect();
+    } 
+
+
+    /// Adds the given type to the set of valid types
+    pub fn add(&mut self, new_type: Type) {
+        self.valid_types.push(new_type);
+    }
+
+
+    /// Removes the given type from the set of valid types
+    pub fn remove(&mut self, to_remove: &Type) {
+        self.valid_types = self.valid_types
+                               .iter()
+                               .filter(|t| *t != to_remove)
+                               .cloned()
+                               .collect();
+    }
+
+
+    /// Removes all values from the set of valid types
+    pub fn clear(&mut self) {
+        self.valid_types = vec![];
+    }
+
+
+    /// True if the set of valid types is empty, otherwise returns false
+    pub fn is_empty(&self) -> bool {
+        self.valid_types.is_empty()
+    }
+
+
+    /// Returns a new [`TypeField`] containing only those types present in the sets of valid types
+    /// of both this type field and the passed type field.
+    pub fn intersection(&self, other: &Self) -> Self {
+        let intersection = self.valid_types
+                               .iter()
+                               .filter(|t| other.valid_types.contains(t))
+                               .cloned()
+                               .collect();
+        TypeField { valid_types: intersection }
+    }
+
+
+    /// True if this type field contains the passed type, otherwise false
+    pub fn contains(&self, other: &Type) -> bool {
+        self.valid_types.contains(other)
+    }
+
+
+    /// True if there is any numerical type in the current set of valid types, otherwise false
+    pub fn contains_numeric(&self) -> bool {
+        self.valid_types.iter()
+            .filter(|t| type_is_numeric(t))
+            .cloned()
+            .collect::<Vec<Type>>()
+            .len() > 0
+    }
+}
+
+
+pub fn get_expr_type(expr: &SyntaxTree) -> Result<TypeField, Box<dyn Error>> {
+    match &expr.node {
+        SyntaxNode::BinaryOperation(op, l, r) => get_binary_operation_type(
+            op.to_string(), 
+            get_expr_type(&*l)?, 
+            get_expr_type(&*r)?
+        ),
+
+        SyntaxNode::IntLiteral(_) => {
+            let mut type_field = TypeField::new();
+            type_field.restrict_numeric();
+            Ok(type_field)
+        }
+
+        SyntaxNode::StringLiteral(_) => {
+            let mut type_field = TypeField::new();
+            type_field.clear();
+            type_field.add(Type::new(String::from("str"), false, vec![])?);
+            Ok(type_field)
+        },
+        _ => todo!()
+    }
+}
+
+
+fn get_binary_operation_type(op: String, l_type: TypeField, r_type: TypeField) -> Result<TypeField, Box<dyn Error>> {
+    let intersection: TypeField = l_type.intersection(&r_type);
+    match op.as_str() {
+        // two numerical arguments and a numerical output
+        "+" | "-" | "*" | "/" | "**" | "%" | "&" | "|" | ">>" | ">>>" | "<<" => {
+            match intersection.contains_numeric() {
+                true => Ok(intersection),
+                false => Err(Box::new(TypeError::new(TypeField::new_numeric(), intersection)))
+            }
+        }
+
+        "&&" | "||" => unimplemented!("Have not yet implemented booleans!"),
+        ">" | "<" | ">=" | "<=" => unimplemented!("Have not yet implemented booleans!"),
+        "==" | "!=" => unimplemented!("Have not yet implemented booleans!"),
+        _ => panic!("Did not recognise operator {}", op)
+    }
+}
+
+
+fn type_is_numeric(t: &Type) -> bool {
+    match t.basic_type {
+        SimpleType::I32
+        | SimpleType::U32 => true,
+        _ => false
+    }
+}

--- a/src/transpiler/transpile_c.rs
+++ b/src/transpiler/transpile_c.rs
@@ -164,6 +164,8 @@ impl Transpiler {
             SyntaxNode::StringLiteral(s) => Ok(format!("\"{}\"", s)),
             SyntaxNode::IntLiteral(n) => Ok(n.to_string()),
             SyntaxNode::Identifier(id) => Ok(id.to_owned()),
+            SyntaxNode::BoolLiteral(true) => Ok("true".to_owned()),
+            SyntaxNode::BoolLiteral(false) => Ok("false".to_owned()),
             SyntaxNode::Program(_) => panic!("Got program when I should not have!"),
             SyntaxNode::FunctionCall(func_id, args) => {
                 let args: Vec<String> = args.iter()


### PR DESCRIPTION
Added typechecking to ensure the following semantic conditions are met:
- While and selection conditions have the boolean type,
- Assignment and reassignment statements have expressions of the same type as the variable they are being assigned to,
- Function calls have the correct number and type of arguments