### PR TITLE
Return-type-checking

### DIFF
--- a/src/parser/errors.rs
+++ b/src/parser/errors.rs
@@ -1,6 +1,6 @@
 use std::{fmt, error};
 
-use super::token::{Token, TokenType};
+use super::{token::{Token, TokenType}, types::Type};
 
 
 #[derive(Debug, Clone)]
@@ -59,7 +59,8 @@ pub enum ParsingError {
     // token encountered, token expected
     UnexpectedToken(Token, ExpectedToken),
     MissingSemicolon(usize),
-    InvalidTypeName(String)
+    InvalidTypeName(String),
+    ReturnTypeMismatch(Type, Type, usize, usize)
 }
 
 
@@ -69,7 +70,9 @@ impl fmt::Display for ParsingError {
             Self::UnexpectedToken(token, expected) => write!(f, "Unexpected token {} at line {}, col {}, expected {:?}", 
                 format!("{:?}", token.token_type), token.line_number, token.col_number + 1, expected),
             Self::MissingSemicolon(line) => write!(f, "Missing semicolon on line {}", line),
-            Self::InvalidTypeName(name) => write!(f, "{} is not a valid type name", name)
+            Self::InvalidTypeName(name) => write!(f, "{} is not a valid type name", name),
+            Self::ReturnTypeMismatch(got, expected, line, col) => 
+                write!(f, "Type mismatch at line {}, col {}, expected {:?}, got {:?}", line, col, got.basic_type, expected.basic_type)
         }
     }
 }

--- a/src/parser/errors.rs
+++ b/src/parser/errors.rs
@@ -72,7 +72,7 @@ impl fmt::Display for ParsingError {
             Self::MissingSemicolon(line) => write!(f, "Missing semicolon on line {}", line),
             Self::InvalidTypeName(name) => write!(f, "{} is not a valid type name", name),
             Self::ReturnTypeMismatch(got, expected, line, col) => 
-                write!(f, "Type mismatch at line {}, col {}, expected {:?}, got {:?}", line, col, got.basic_type, expected.basic_type)
+                write!(f, "Type mismatch at line {}, col {}, expected {:?}, got {:?}", line, col, expected.basic_type, got.basic_type)
         }
     }
 }

--- a/src/parser/lexing.rs
+++ b/src/parser/lexing.rs
@@ -437,6 +437,7 @@ impl Scanner {
                             "true" => return Ok(TokenType::BoolLiteral(true)),
                             "false" => return Ok(TokenType::BoolLiteral(false)),
                             "match" => return Ok(TokenType::MatchKeyword),
+                            "as" => return Ok(TokenType::AsKeyword),
                             // is not a keyword, and therefore is an identifier
                             _ => return Ok(TokenType::Identifier(token_text.to_owned()))
                         }

--- a/src/parser/parsing.rs
+++ b/src/parser/parsing.rs
@@ -1013,7 +1013,10 @@ impl Parser {
         let expr_type: Type = get_expr_type(&expr, &self.current_symbol_table.borrow())?;
         // check that the returned value is type-compatible with the return type of the function
         match &self.current_return_type {
-            Some(t) => assert!(expr_type.is_compatible_with(&t)),
+            Some(t) => if !expr_type.is_compatible_with(&t) {
+                return Err(Box::new(ParsingError::ReturnTypeMismatch(expr_type, t.clone(), line_num, col_num)))
+            }
+
             None => panic!()
         }
 

--- a/src/parser/token.rs
+++ b/src/parser/token.rs
@@ -62,6 +62,7 @@ pub enum TokenType {
     InKeyword,
     EnumKeyword,
     MatchKeyword,
+    AsKeyword,
     StrLiteral(String),
     IntLiteral(u64),
     BoolLiteral(bool),

--- a/tests/test_incorrect_return_type.skj
+++ b/tests/test_incorrect_return_type.skj
@@ -1,0 +1,3 @@
+fn main() -> i32 {
+    return true;
+}

--- a/tests/test_tuples.skj
+++ b/tests/test_tuples.skj
@@ -1,4 +1,4 @@
-fn test_integer_tuple(a: i64) -> (i32, i64, u32, u64) {
+fn test_integer_tuple(a: i64) -> (i32, i64, u32, u64, bool) {
     let x: (i32, i64, u32, u64, bool) = (1, a, 3, 4, true);
     let y: bool = x[4];
     return x;


### PR DESCRIPTION
Resolves #14: Added type casting with the `as` keyword.